### PR TITLE
Workaround for endpoint deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This repository contains two scripts:
 
  * **upload.js** - uploads the contents of an archived Pipedrive account onto a new account
 ---
-## Important:
 
-Due to deprecated API endpoints, please make sure your `/lib/objects.json:23` and `node_modules/pipedrive/lib/Pipedrive.js:63`
-use `mailThreads` and not `emailThreads`!
+## Important
+
+* Due to deprecated API endpoints, please make sure your `/lib/objects.json:23` and `node_modules/pipedrive/lib/Pipedrive.js:63` use `mailThreads` and not `emailThreads`!
+
 ---
 
 ### Download.js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This repository contains two scripts:
 
  * **upload.js** - uploads the contents of an archived Pipedrive account onto a new account
 ---
-### Note:
+## Important:
+
 Due to deprecated API endpoints, please make sure your `/lib/objects.json:23` and `node_modules/pipedrive/lib/Pipedrive.js:63`
 use `mailThreads` and not `emailThreads`!
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Pipedrive snapshot downloader & uploader
 ========================================
 
+
 ## Usage
 
 This repository contains two scripts:
@@ -8,7 +9,11 @@ This repository contains two scripts:
  * **download.js** - downloads/archives a nearly complete content of a Pipedrive account into a single archive
 
  * **upload.js** - uploads the contents of an archived Pipedrive account onto a new account
-
+---
+### Note:
+Due to deprecated API endpoints, please make sure your `/lib/objects.json:23` and `node_modules/pipedrive/lib/Pipedrive.js:63`
+use `mailThreads` and not `emailThreads`!
+---
 
 ### Download.js
 

--- a/lib/objects.json
+++ b/lib/objects.json
@@ -20,7 +20,7 @@
 		"deals",
 		"notes",
 		"activities",
-		"emailThreads",
+		"mailThreads",
 		"filters",
 		"goals",
 		"pushNotifications"


### PR DESCRIPTION
Suggested changes in lib/objects.json & node_modules/pipedrive, corresponding change to readme